### PR TITLE
Scrum-153 fix bug with template empty line in html file

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "flowbite": "^2.3.0",
         "flowbite-react": "^0.9.0",
         "formidable": "^3.5.1",
+        "js-cookie": "^3.0.5",
         "lucide-react": "^0.395.0",
         "next": "14.2.3",
         "react": "^18",
@@ -35,6 +36,7 @@
       "devDependencies": {
         "@tailwindcss/typography": "^0.5.13",
         "@types/formidable": "^3.4.5",
+        "@types/js-cookie": "^3.0.6",
         "@types/node": "^20",
         "@types/react": "^18",
         "@types/react-dom": "^18",

--- a/src/app/ui/Tiptap.tsx
+++ b/src/app/ui/Tiptap.tsx
@@ -53,6 +53,19 @@ const Tiptap = ({ onChange, content }: any) => {
   }, []);
 
   const handleUpload = async () => {
+
+    const preserveEmptyLines = (content: string): string => {
+      return content
+        // 將已有的空段落轉換為包含 &nbsp; 的格式
+        .replace(/<p>\s*<\/p>/g, '<p>&nbsp;</p>')
+        // 處理連續空行，但保留它們
+        .replace(/(<p>&nbsp;<\/p>)+/g, (match) => match)
+        // 確保段落之間有換行符號
+        .replace(/<\/p><p>/g, '</p>\n<p>');
+    };
+
+    const formattedContent = preserveEmptyLines(editorContent);
+
     const html = `
     <!DOCTYPE html>
     <html lang="zh-TW">
@@ -61,7 +74,7 @@ const Tiptap = ({ onChange, content }: any) => {
         <title>加入 AWS Educate Taiwan 雲端校園大使證照陪跑計畫</title>
     </head>
     <body>
-        ${editorContent}
+        ${formattedContent}
     </body>
     </html>`;
     const blob = new Blob([html], { type: "text/html" });


### PR DESCRIPTION
## Description
<!--
請提供這個 PR 的簡要描述：
- 這個 PR 解決了什麼問題？
- 為什麼需要這個變更？
- 如何實現的？
-->
Create Template 的空行，在生成後的 .html file 內消失，目前確認應該是因為缺少保留字 `&nbsp;`，寫了一個 `function preserveEmptyLines` 判斷空行的狀況並處理，在 save html 的時候可以將空行保留下來。

## Type of Change
<!--
請勾選適用的變更類型（可多選）
-->
- [X] 🐛 Bug Fix（修復 bug）
- [ ] ✨ New Feature（新功能）
- [ ] 💄 UI/UX（介面或使用者體驗優化）
- [ ] 🔨 Refactor（程式碼重構）
- [ ] 📝 Documentation（文件更新）
- [ ] 🔧 Configuration（配置變更）
- [ ] 🚀 Performance（效能優化）
- [ ] ✅ Test（測試相關）
- [ ] 🔒 Security（安全性相關）

## Related Issues
<!--
請列出相關的 issue 編號
例如：Closes #123, Relates to #456
-->
[SCRUM-153](https://aws-educate-cloud-ambassador-dev-team.atlassian.net/browse/SCRUM-153)

## Testing
<!--
請描述如何測試這些變更：
- 已執行哪些測試？
- 如何驗證這些變更？
- 是否需要特別的測試步驟？
-->
- [X] 完成測試
可以看一下 Created At 2024-11-10 15:20:22 的那份 .html 檔案，有成功處理空行被保留的行為


## Screenshots/Videos
<!--
如果是 UI 變更，請提供截圖或影片
-->

## Checklist
<!--
在提交 PR 前，請確認以下項目：
-->
- [x] 我已經測試過這些變更
- [ ] 我已經更新相關文件
- [x] 我的程式碼遵循專案的程式碼規範
- [x] 我已經處理所有的 console warnings/errors
- [x] 我已經移除所有的 console.log
- [ ] 我已經新增必要的測試案例
- [ ] 所有現有的測試都能通過

## Additional Notes
<!--
其他補充說明或注意事項
-->

[SCRUM-153]: https://aws-educate-cloud-ambassador-dev-team.atlassian.net/browse/SCRUM-153?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ