### PR TITLE
Scrum 231 frontend the token expiry time in local storage doesnt match jwt

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -38,13 +38,13 @@ export default function Page() {
     try {
       const response = await submitLogin(JSON.stringify(formData));
 
-      console.log(response);
       alert(response.message);
 
       if (response.message === "Login successful") {
         localStorage.setItem("access_token", response.access_token);
 
-        const tokenExpiryTime = new Date().getTime() + 24 * 60 * 60 * 10000;
+        // Set token expiry time to 24 hours
+        const tokenExpiryTime = new Date().getTime() + 24 * 60 * 60 * 1000;
         localStorage.setItem("token_expiry_time", tokenExpiryTime.toString());
 
         router.push("/sendEmail");


### PR DESCRIPTION
## Description
<!--
請提供這個 PR 的簡要描述：
- 這個 PR 解決了什麼問題？
- 為什麼需要這個變更？
- 如何實現的？
-->
原先前端的 expiry time 設定10天，修正為1天。

## Type of Change
<!--
請勾選適用的變更類型（可多選）
-->
- [x] 🐛 Bug Fix（修復 bug）
- [ ] ✨ New Feature（新功能）
- [ ] 💄 UI/UX（介面或使用者體驗優化）
- [ ] 🔨 Refactor（程式碼重構）
- [ ] 📝 Documentation（文件更新）
- [ ] 🔧 Configuration（配置變更）
- [ ] 🚀 Performance（效能優化）
- [ ] ✅ Test（測試相關）
- [ ] 🔒 Security（安全性相關）

## Related Issues
<!--
請列出相關的 issue 編號
例如：Closes #123, Relates to #456
-->
[SCRUM-231](https://aws-educate-cloud-ambassador-dev-team.atlassian.net/browse/SCRUM-231)

## Testing
<!--
請描述如何測試這些變更：
- 已執行哪些測試？
- 如何驗證這些變更？
- 是否需要特別的測試步驟？
-->
N/A

## Screenshots/Videos
N/A

## Checklist
<!--
在提交 PR 前，請確認以下項目：
-->
- [x] 我已經測試過這些變更
- [ ] 我已經更新相關文件
- [x] 我的程式碼遵循專案的程式碼規範
- [x] 我已經處理所有的 console warnings/errors
- [x] 我已經移除所有的 console.log
- [ ] 我已經新增必要的測試案例
- [x] 所有現有的測試都能通過

## Additional Notes
<!--
其他補充說明或注意事項
-->
N/A

[SCRUM-231]: https://aws-educate-cloud-ambassador-dev-team.atlassian.net/browse/SCRUM-231?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ