### PR TITLE
fix: preserve RSVP attendance response status

### DIFF
--- a/src/app/ui/rsvpService/rsvp-confirmation-form.tsx
+++ b/src/app/ui/rsvpService/rsvp-confirmation-form.tsx
@@ -7,6 +7,7 @@ import RsvpStatusBanner from "./rsvp-status-banner";
 import RsvpRadioGroup from "./rsvp-radio-group";
 import RsvpSubmitButton from "./rsvp-submit-button";
 import type { RsvpStatus, RsvpStatusResponse, RsvpToken, RsvpUpdateResponse } from "./types";
+import { createRsvpUpdatePayload, isRsvpChoice, type RsvpChoice } from "./rsvp-status";
 
 interface RsvpConfirmationFormProps {
   token: string;
@@ -71,7 +72,7 @@ export default function RsvpConfirmationForm({ token }: RsvpConfirmationFormProp
   const [pageError, setPageError] = useState<PageError | null>(null);
   const [rsvpStatus, setRsvpStatus] = useState<RsvpStatus>("PENDING");
   const [campaignData, setCampaignData] = useState<CampaignDisplayData | null>(null);
-  const [selectedOption, setSelectedOption] = useState<"ATTEND" | "NOT_ATTEND" | null>(null);
+  const [selectedOption, setSelectedOption] = useState<RsvpChoice | null>(null);
   const [isEditing, setIsEditing] = useState(true);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [lastEditedTime, setLastEditedTime] = useState<string | null>(null);
@@ -168,9 +169,7 @@ export default function RsvpConfirmationForm({ token }: RsvpConfirmationFormProp
             Authorization: `Bearer ${token}`,
             "Content-Type": "application/json",
           },
-          body: JSON.stringify({
-            action: selectedOption,
-          }),
+          body: JSON.stringify(createRsvpUpdatePayload(selectedOption)),
         });
 
         if (res.status === 401) {
@@ -205,9 +204,16 @@ export default function RsvpConfirmationForm({ token }: RsvpConfirmationFormProp
         }
 
         const data: RsvpUpdateResponse = await res.json();
-        const current = data.data.rsvp_status;
+        // Prefer the current API field, while accepting the legacy field used
+        // by older deployed RSVP-service versions.
+        const current = data.data.rsvp_status ?? data.data.currentStatus;
+        if (!isRsvpChoice(current)) {
+          setPageError("system_error");
+          break;
+        }
+
         setRsvpStatus(current);
-        if (current !== "PENDING") setSelectedOption(current);
+        setSelectedOption(current);
         setIsEditing(false);
         setLastEditedTime(formatDatetime(new Date().toISOString()));
         break;

--- a/src/app/ui/rsvpService/rsvp-status.ts
+++ b/src/app/ui/rsvpService/rsvp-status.ts
@@ -1,0 +1,16 @@
+import type { RsvpStatus } from "./types";
+
+export type RsvpChoice = Exclude<RsvpStatus, "PENDING">;
+
+/**
+ * Keep the value sent to the RSVP API identical to the value selected in the
+ * UI.  In particular, do not use a truthy/falsy conversion here: ATTEND and
+ * NOT_ATTEND are both valid, distinct choices.
+ */
+export function createRsvpUpdatePayload(choice: RsvpChoice): { action: RsvpChoice } {
+  return { action: choice };
+}
+
+export function isRsvpChoice(value: unknown): value is RsvpChoice {
+  return value === "ATTEND" || value === "NOT_ATTEND";
+}

--- a/src/app/ui/rsvpService/types.ts
+++ b/src/app/ui/rsvpService/types.ts
@@ -24,6 +24,8 @@ export interface RsvpStatusResponse {
 export interface RsvpUpdateResponse {
   status: "SUCCESS";
   data: {
-    rsvp_status: RsvpStatus;
+    rsvp_status?: RsvpStatus;
+    // Supported for compatibility with older RSVP-service responses.
+    currentStatus?: RsvpStatus;
   };
 }


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 🎉
-->

## Description

This PR fixes the RSVP response display and persistence flow. The selected attendance option is now preserved in the API request, and the response parser supports both the current and legacy RSVP status fields. Invalid response statuses are rejected instead of being displayed as a submitted response.

## Type of Change

- [x] 🐛 Bug Fix (fixes an issue)
- [ ] ✨ New Feature (introduces a new feature)
- [ ] 💄 UI/UX (improves interface or user experience)
- [ ] 🔨 Refactor (code refactoring)
- [ ] 📝 Documentation (updates documentation)
- [ ] 🔧 Configuration (changes configuration)
- [ ] 🚀 Performance (improves performance)
- [ ] ✅ Test (related to tests)
- [ ] 🔒 Security (addresses security concerns)

## Related Issues

[SCRUM-611](https://aws-educate-cloud-ambassador-dev-team.atlassian.net/browse/SCRUM-661)

## Testing

- TypeScript type-check passed.
- ESLint passed.
- Prettier check passed.
- Manually verified the ATTEND flow in the local RSVP page. The page displayed 「是，我會準時出席。」 before and after reload, confirming the persisted status remained ATTEND.
- The NOT_ATTEND mapping is explicitly preserved as `action: NOT_ATTEND` in the shared payload helper.

## Screenshots/Videos

<img width="1624" height="1061" alt="image" src="https://github.com/user-attachments/assets/775d9cd3-5ffe-42bc-9bc6-376c533a3a10" />


## Checklist

- [x] I have tested these changes.
- [ ] I have updated the relevant documentation.
- [x] My code adheres to the project’s code standards.
- [x] I have addressed all console warnings/errors introduced by this change.
- [x] I have removed all `console.log` or `print()` statements introduced by this change.
- [ ] I have added necessary test cases.
- [x] All existing checks pass.

## Additional Notes

The repository does not currently provide an npm test script or configured test runner, so this PR relies on type-checking, linting, formatting checks, and manual end-to-end verification.

<!--
Reminder:
Before submitting your PR, please review the **Coding Guidelines**: https://aws-educate-tw.notion.site/TPET-Backend-Coding-Guidelines-12e6bfee681780ac89c3cf43854380d4?pvs=4
-->

[SCRUM-611]: https://aws-educate-cloud-ambassador-dev-team.atlassian.net/browse/SCRUM-611?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ