### PR TITLE
SCRUM 667 Fix jwt_token column validation for rsvp email

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,2 +1,2 @@
 NEXT_PUBLIC_API_ENDPOINT = https://api.tpet.aws-educate.tw/dev
-NEXT_PUBLIC_RSVP_PAGE_URL = https://dev.tpet-aws.educate.tw/rsvpPage
+NEXT_PUBLIC_RSVP_PAGE_URL=https://tpet-dev.aws-educate.tw/rsvpPage

--- a/src/app/ui/emailService/email-service-recipients.tsx
+++ b/src/app/ui/emailService/email-service-recipients.tsx
@@ -29,6 +29,8 @@ interface Column {
 
 const RSVP_JWT_TOKEN_COLUMN = "jwt_token";
 
+const getSpreadsheetNameWithoutExtension = (fileName: string) => fileName.replace(/\.xlsx$/i, "");
+
 export default function EmailServiceRecipients({
   onNext,
   emailData,
@@ -55,13 +57,20 @@ export default function EmailServiceRecipients({
   /** 讓父層一旦有 dropdown 選擇，就先把 file_id 送上去（情境1） */
   useEffect(() => {
     if (selectedSpreadsheetInfo) {
+      if (emailData.isRsvp) {
+        setFileName(getSpreadsheetNameWithoutExtension(selectedSpreadsheetInfo.file_name));
+        setIsSave(false);
+        onSave?.("", "", "");
+        return;
+      }
+
       onSave?.(
         selectedSpreadsheetInfo.file_name,
         selectedSpreadsheetInfo.file_id,
         selectedSpreadsheetInfo.file_url
       );
     }
-  }, [selectedSpreadsheetInfo, onSave]);
+  }, [emailData.isRsvp, selectedSpreadsheetInfo, onSave]);
 
   /** 只要 user 有任何編輯（包含 dropdown 案例），就清空父層的 file_id 等（情境2 & 3） */
   const handleTableChange = useCallback(

--- a/src/app/ui/emailService/email-service-recipients.tsx
+++ b/src/app/ui/emailService/email-service-recipients.tsx
@@ -27,6 +27,8 @@ interface Column {
   isStandard?: boolean;
 }
 
+const RSVP_JWT_TOKEN_COLUMN = "jwt_token";
+
 export default function EmailServiceRecipients({
   onNext,
   emailData,
@@ -163,7 +165,19 @@ export default function EmailServiceRecipients({
 
     try {
       // 1. Create Excel file from JSON data
-      const worksheet = XLSX.utils.json_to_sheet(excel, { header: columns });
+      const shouldIncludeRsvpTokenColumn = emailData.isRsvp;
+      const uploadColumns =
+        shouldIncludeRsvpTokenColumn && !columns.includes(RSVP_JWT_TOKEN_COLUMN)
+          ? [...columns, RSVP_JWT_TOKEN_COLUMN]
+          : columns;
+      const uploadExcel = shouldIncludeRsvpTokenColumn
+        ? excel.map(row => ({
+            ...row,
+            [RSVP_JWT_TOKEN_COLUMN]: row[RSVP_JWT_TOKEN_COLUMN] ?? "",
+          }))
+        : excel;
+
+      const worksheet = XLSX.utils.json_to_sheet(uploadExcel, { header: uploadColumns });
       const workbook = XLSX.utils.book_new();
       XLSX.utils.book_append_sheet(workbook, worksheet, "Sheet1");
 


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 🎉
-->

<!-- markdownlint-disable MD041 -->

## Description
This PR fixes an issue where RSVP email sending fails if the user does not manually add a `jwt_token` column to the spreadsheet.

`jwt_token` is a system-generated field. It should be generated by the backend during the RSVP email flow and replaced into the RSVP link, so users should not be required to fill it in manually on the Recipients page.

With this change, when saving/uploading a spreadsheet for an RSVP email, the frontend automatically adds a hidden `jwt_token` column to the actual Excel file being uploaded. The UI remains unchanged: users will not see or edit the `jwt_token` column.

<!--
Provide a brief description of this PR:
- What issue does this PR address?
- Why is this change necessary?
- How was it implemented?
-->

## Type of Change

<!--
Select the type(s) of changes made (you can select multiple):
-->

- [x] 🐛 Bug Fix (fixes an issue)
- [ ] ✨ New Feature (introduces a new feature)
- [ ] 💄 UI/UX (improves interface or user experience)
- [ ] 🔨 Refactor (code refactoring)
- [ ] 📝 Documentation (updates documentation)
- [ ] 🔧 Configuration (changes configuration)
- [ ] 🚀 Performance (improves performance)
- [ ] ✅ Test (related to tests)
- [ ] 🔒 Security (addresses security concerns)

## Related Issues
[SCRUM-667](https://aws-educate-cloud-ambassador-dev-team.atlassian.net/browse/SCRUM-667)

<!--
List related issue numbers or links:
Example: Closes SCRUM-123, Relates to SCRUM-456
-->

## Testing
[Preview](https://deploy-preview-123--tpet-dev-aws-educate.netlify.app/)

<!--
Describe how these changes were tested:
- What tests were performed?
- How were these changes verified?
- Are there any specific test steps required?
-->

## Screenshots/Videos
<img width="2880" height="1514" alt="image" src="https://github.com/user-attachments/assets/f9fb31b8-9b8e-4c43-a07e-81861c883aee" />
<img width="2880" height="1612" alt="螢幕擷取畫面 2026-08-16 180302" src="https://github.com/user-attachments/assets/a54d4b72-f522-4d8f-8013-ba4ddbd3d27f" />

<!--
Provide screenshots or videos to demonstrate the changes (if applicable).
-->

## Checklist

<!--
Ensure the following items are checked before submitting the PR:
-->

- [x] I have tested these changes.
- [ ] I have updated the relevant documentation.
- [x] My code adheres to the project’s code standards.
- [x] I have addressed all console warnings/errors.
- [x] I have removed all `console.log` or `print()` statements.
- [ ] I have added necessary test cases.
- [ ] All existing tests pass.

## Additional Notes
Also updated the RSVP page URL for the dev environment, changing the link prefix to `https://tpet-dev.aws-educate.tw/rsvpPage`.

<!--
Add any other relevant notes or considerations:
-->

<!--
Reminder:
Before submitting your PR, please review the **Coding Guidelines**: https://aws-educate-tw.notion.site/TPET-Backend-Coding-Guidelines-12e6bfee681780ac89c3cf43854380d4?pvs=4
-->

<!-- markdownlint-enable MD041 -->


[SCRUM-667]: https://aws-educate-cloud-ambassador-dev-team.atlassian.net/browse/SCRUM-667?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ